### PR TITLE
Add confirm_warnings config option

### DIFF
--- a/SQribe/HELP.txt
+++ b/SQribe/HELP.txt
@@ -63,6 +63,9 @@ Zip data insert script files to save disk space (default: false).
 /confirm_start:
 Require a keypress to begin a backup (default: true).
 
+/confirm_warnings:
+Require a keypress to continue when warnings occur
+
 /console_dark_mode:
 When enabled output is light in color; dark when disabled (default: true).
 
@@ -139,6 +142,9 @@ Makes a beep sound when a SQribe operation completes (default: true).
 
 /confirm_start:
 Require a keypress to begin a restore (default: true).
+
+/confirm_warnings:
+Require a keypress to continue when warnings occur
 
 /console_dark_mode:
 When enabled output is light in color; dark when disabled (default: true).
@@ -221,6 +227,7 @@ Backup file format:
     "chunk_size_mb": 10,
     "compress_data": false,
     "confirm_start": true,
+    "confirm_warnings": true,
     "console_dark_mode": true,
     "data_exclusions": "",
     "data_source": "server=localhost; database=Adv... etc.",
@@ -236,6 +243,7 @@ Restore file format:
     "mode": "restore",
     "beep_on_completion": true,
     "confirm_start": true,
+    "confirm_warnings": true,
     "console_dark_mode": true,
     "data_source": "server=localhost; database=Adv... etc.",
     "erase_database": true,

--- a/SQribe/Program.cs
+++ b/SQribe/Program.cs
@@ -566,7 +566,7 @@ public class App
                                     settings.Log("- Result: Could not detect SQL Server edition");
                                 }
                                 
-                                if (supported == false)
+                                if (supported == false && settings.ConfirmWarnings)
                                 {
                                     output.WriteLine (string.Empty, token);
                                     output.WriteLine("Press [Y] or [ENTER] to continue anyway, or any other key to cancel" + Constants.Ellipsis, token, (int)Constants.GetColor("warning", settings.ConsoleDarkMode));
@@ -686,7 +686,7 @@ public class App
                                 }
                                 
 
-                                if (foundPermissions.Count < permissionsToCheck.Length)
+                                if (foundPermissions.Count < permissionsToCheck.Length && settings.ConfirmWarnings)
                                 {
                                     var missingPermissions = string.Empty;
 

--- a/SQribe/Settings.cs
+++ b/SQribe/Settings.cs
@@ -45,6 +45,7 @@ public interface ISettings
     bool ChunkData { get; set; }
     bool CompressData { get; set; }
     bool ConfirmStart { get; set; }
+    bool ConfirmWarnings { get; set; }
     bool ConnectionGood { get; set; }
     bool ConsoleDarkMode { get; set; }
     bool DoNotLog { get; set; }
@@ -348,6 +349,7 @@ internal class Settings : ISettings
     public bool ChunkData { get; set; }
     public bool CompressData { get; set; }
     public bool ConfirmStart { get; set; }
+    public bool ConfirmWarnings { get; set; }
     public bool ConnectionGood { get; set; }
     public bool ConsoleDarkMode { get; set; }
     public bool DoNotLog
@@ -504,6 +506,7 @@ internal class Settings : ISettings
         //OutputPath = ProcessFolderPath(Environment.GetFolderPath(Environment.SpecialFolder.DesktopDirectory));
         CompressData = false;
         ConfirmStart = true;
+        ConfirmWarnings = true;
         ConsoleDarkMode = true;
         SuppressStartWarnings = false;
         BeepOnCompletion = true;
@@ -685,6 +688,11 @@ internal class Settings : ISettings
             if (item.Key.ToLower() == "confirm_start")
             {
                 ConfirmStart = jt.Value<bool>();
+            }
+
+            if (item.Key.ToLower() == "confirm_warnings")
+            {
+                ConfirmWarnings = jt.Value<bool>();
             }
 
             if (item.Key.ToLower() == "data_blacklist" || item.Key.ToLower() == "data_exclusions")

--- a/SQribe/backup-defaults.json
+++ b/SQribe/backup-defaults.json
@@ -4,6 +4,7 @@
     "chunk_size_mb": 10,
     "compress_data": false,
     "confirm_start": true,
+    "confirm_warnings": true,
     "console_dark_mode": true,
     "data_exclusions": "",
     "objects": "all",

--- a/SQribe/restore-defaults.json
+++ b/SQribe/restore-defaults.json
@@ -1,6 +1,7 @@
 {
     "beep_on_completion": true,
     "confirm_start": true,
+    "confirm_warnings": true,
     "console_dark_mode": true,
     "erase_database": true,
     "objects": "all",


### PR DESCRIPTION
### Adds confirm_warnings config option to enable non-interactive automation

**Problem**
Sqribe currently prompts the user to manually confirm continuation when warnings such as “Unsupported SQL Server edition” are encountered:

```
• Server edition ➜  Unsupported SQL Server edition                                                                                                            

Press [Y] or [ENTER] to continue anyway, or any other key to cancel… 
```

This behavior blocks non-interactive or automated backup workflows, such as cron jobs or CI/CD pipelines.

**Solution**
This PR introduces a new configuration option:

`confirm_warnings: boolean`
- The default is `true`, preserving current interactive behavior for all existing users
- When set to `false`, Sqribe will bypass confirmation prompts and proceed with the operation

This change enables running Sqribe in automated environments without manual intervention

**Notes**
- Backward-compatible (default behavior unchanged).
- Documentation updated to reflect the new option.